### PR TITLE
Fix git dependency with libc6-dev

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,3 +1,8 @@
+- name: Remove binutils package
+  apt:
+    name: binutils
+    state: absent
+
 - name: Ensure sudo is installed
   apt:
     name=sudo


### PR DESCRIPTION
Removes binutils so the correct version is installed when installing git